### PR TITLE
Add planning docs for weekend projects portfolio revamp

### DIFF
--- a/docs/planning/weekend-projects/prd.md
+++ b/docs/planning/weekend-projects/prd.md
@@ -1,0 +1,119 @@
+---
+title: "Weekend Projects Portfolio PRD"
+author: "AI Planning Agent"
+created: "2025-02-14"
+status: "Draft"
+---
+
+# Weekend Projects Portfolio – Product Requirements Document
+
+## 1. Executive Summary
+- Transform the existing “Weekend Projects” page into a long-lived portfolio destination that automatically scales as new side projects are added.
+- Introduce a hero section that visualizes Ta Khongsap’s GitHub activity (1,500+ commits in the past 12 months) to instantly demonstrate credibility.
+- Create content and layout systems that make it easy to ingest a curated list of applications (from spreadsheets, CMS, or Markdown) and render them as premium case studies.
+- Deliver a flexible design system that highlights experimentation, engineering rigor, and visual flair—aligned with the "ultrathink" creative direction.
+
+## 2. Goals & Non-Goals
+### Goals
+1. Provide a narrative-driven hero that pairs GitHub contribution metrics with a personal mission statement.
+2. Support rich project entries (problem, solution, stack, outcomes, media) sourced from a structured dataset.
+3. Maintain responsive, accessible layouts across devices while preserving high visual polish.
+4. Enable future automation (GitHub API sync, Notion/CSV import) without reworking the UI.
+5. Improve discovery by clustering projects into themes (AI, data, creative coding, finance, weekend experiments).
+6. Surface credibility markers: commit streaks, GitHub followers/stars, testimonials, publication mentions.
+
+### Non-Goals
+- Full CMS implementation or external database sync (scoped for later).
+- Building an analytics dashboard beyond existing site analytics.
+- Rewriting the overall site navigation or brand system.
+
+## 3. Target Audience & Use Cases
+| Audience | Needs | Experience Goals |
+|----------|-------|------------------|
+| Hiring managers / clients | Quick validation of technical depth and consistency | Immediate credibility via GitHub hero, curated highlights, links to source code |
+| Collaborators & peers | Understand experimentation focus and project diversity | Filterable showcase, deep dives with stack + outcomes |
+| Community / students | Learn from weekend builds and creative problem-solving | Narrative case studies, behind-the-scenes insights |
+
+## 4. User Stories
+1. As a prospect, I can scan the hero section and understand Ta’s recent activity, core technologies, and ethos in <10 seconds.
+2. As a recruiter, I can filter to AI/Data projects and see quantifiable outcomes and repository links.
+3. As Ta, I can add a new project entry in one place and have it automatically appear with consistent styling and metadata.
+4. As a returning visitor, I can see what’s new through “Latest Weekend Builds” or timeline modules.
+5. As a tech enthusiast, I can view interactive or video demos without leaving the page.
+
+## 5. Experience Principles ("Ultrathink" Lens)
+- **Systems-level storytelling**: Show the pipeline from idea → prototype → measurable impact.
+- **Visualized momentum**: Motion graphics or sparklines illustrating contribution streaks and shipped experiments.
+- **Credibility with warmth**: Pair metrics with human voice (quotes, reflections, lessons learned).
+- **Expandable depth**: Summaries up front, optional deep dives via accordions or modal case studies.
+
+## 6. Functional Requirements
+### 6.1 Hero Module
+- Display GitHub profile avatar, username, tagline, and high-impact stat callouts (commits, repos, contribution streak).
+- Include dynamic visualization (heatmap, radial chart, or bar sparkline) referencing the latest 12 months of contributions.
+- Allow manual override of stats for storytelling while providing hooks for real API data.
+- CTA buttons: "Explore Projects", "View GitHub".
+
+### 6.2 Project Data Pipeline
+- Accept structured data (TypeScript array, JSON, or CMS export) with fields: title, summary, category, problem, approach, outcome, stack, links (demo, repo), assets (image/video), timeline, role.
+- Support optional badges (AI, WebGL, Hackathon, Open Source) and flags (Featured, In Progress).
+- Provide markdown-compatible rich text for lessons learned or retrospective notes.
+
+### 6.3 Portfolio Layout
+- Hero > Featured Projects carousel > Filterable grid/list > Deep-dive modals > Personal reflections.
+- Filtering by category, technology, or year.
+- Option to toggle between card grid and timeline view.
+- Smooth scroll anchors for Hero, Featured, Archive, Process, FAQ.
+
+### 6.4 GitHub Integration Layer
+- Service module to fetch contribution stats using GitHub GraphQL API.
+- Cache layer (server-side) with TTL to avoid rate limits; fallback to stored snapshot.
+- Mock data for local development with ability to inject real data at build time.
+
+### 6.5 Content Enhancements
+- Dedicated section for "What I’m Building Next" with backlog teasers.
+- CTA for newsletter signup / contact at end of page.
+- Optional quote/testimonial slider from collaborators.
+
+## 7. Non-Functional Requirements
+- Lighthouse performance score ≥ 90 on mobile & desktop.
+- Adhere to WCAG 2.1 AA (color contrast, keyboard navigation for filters/carousels).
+- Animations GPU-friendly (<200ms for micro-interactions).
+- Reusable components documented in Storybook (stretch goal).
+
+## 8. Data & Content Sources
+- Manual data file (initial) with ability to import from CSV or Notion export.
+- GitHub GraphQL API `user.contributionsCollection` for stats and heatmap.
+- Static assets stored under `public/weekend-projects/` (images, GIFs, videos).
+
+## 9. Analytics & Success Metrics
+- Increase time-on-page by 30% (baseline from analytics).
+- Achieve ≥25% click-through to GitHub profile or project repos.
+- Capture ≥10% newsletter/contact conversions from portfolio visits.
+
+## 10. Risks & Mitigations
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| GitHub API rate limits | Stats fail to load | Cache + fallback JSON snapshot |
+| Large media assets | Slow page load | Optimize images (AVIF/WebP), lazy-load videos |
+| Content staleness | Page loses credibility | Build admin-friendly data file structure + update checklist |
+| Overly busy visuals | Confuse visitors | Progressive disclosure, limit hero data points to ≤3 |
+
+## 11. Release Plan
+### Milestone A – Foundations (Week 1)
+- Finalize data model, hero concept, and visual direction mockups.
+- Implement content ingestion layer and static hero with placeholder data.
+
+### Milestone B – Interactivity (Weeks 2-3)
+- Build GitHub stats service + caching.
+- Implement featured carousel, filters, and responsive layouts.
+- Populate content with initial curated apps (from provided list).
+
+### Milestone C – Polish & Launch (Week 4)
+- Add animations, testimonials, and CTA integration.
+- Conduct accessibility & performance audits; optimize assets.
+- Final content review, QA, and deploy.
+
+## 12. Appendices
+- Inspiration references: GitHub profile summary cards, Read.cv case studies, Linear’s changelog layout.
+- Technical spike suggestions: Chart.js vs. D3 for visualizations, motion libraries (Framer Motion), GitHub GraphQL schema review.

--- a/docs/planning/weekend-projects/tasks.md
+++ b/docs/planning/weekend-projects/tasks.md
@@ -1,0 +1,86 @@
+---
+title: "Weekend Projects Portfolio – Task Plan"
+owner: "Ta Khongsap"
+status: "Draft"
+last_updated: "2025-02-14"
+---
+
+# Execution Plan
+
+> **Legend:** `[ ]` not started · `[~]` in progress · `[x]` complete · `(@)` blocked
+
+## Epic A – Strategy & Content Architecture
+1. **[ ] A1.1 · Audit Current Weekend Projects Experience**
+   - [ ] Capture current screenshots (desktop, mobile, hero, project cards).
+   - [ ] Inventory existing data sources (`projects.ts`, Medium posts, live demos).
+   - [ ] Document pain points & opportunities in FigJam/Notion.
+2. **[ ] A1.2 · Define Content Model & Taxonomy**
+   - [ ] Finalize project schema (fields, optional metadata, relationships).
+   - [ ] Map categories/tags (AI, Data, Creative, Finance, Experiment).
+   - [ ] Draft content governance checklist (how to add/update projects).
+3. **[ ] A1.3 · Assemble Portfolio Narrative**
+   - [ ] Craft hero messaging (mission statement, supporting copy).
+   - [ ] Curate initial “featured five” projects with success metrics.
+   - [ ] Gather testimonials or social proof quotes.
+
+## Epic B – Visual & Interaction Design
+1. **[ ] B2.1 · Hero Concept Exploration**
+   - [ ] Moodboard "ultrathink" references (GitHub profile visuals, dataviz).
+   - [ ] Sketch hero layout options (heatmap vs radial vs sparkline stats).
+   - [ ] Select typography, color, and motion guidelines.
+2. **[ ] B2.2 · Portfolio Layout System**
+   - [ ] Design featured carousel, filter chips, and list/timeline view toggles.
+   - [ ] Define responsive breakpoints (desktop, tablet, mobile) with component specs.
+   - [ ] Create asset templates for project imagery (ratio, overlay treatments).
+3. **[ ] B2.3 · Prototype & Handoff**
+   - [ ] Build high-fidelity prototype in Figma.
+   - [ ] Annotate interactions (hover states, animation durations, scroll behavior).
+   - [ ] Package design tokens + component variants for engineering.
+
+## Epic C – Engineering Implementation
+1. **[ ] C3.1 · Data Layer & CMS Prep**
+   - [ ] Refactor `@/data/projects` to match new schema (featured flags, metrics, media).
+   - [ ] Create import pipeline (e.g., JSON/CSV parser or Notion export adapter).
+   - [ ] Add validation via Zod schema for project entries.
+2. **[ ] C3.2 · Hero & GitHub Activity Visualization**
+   - [ ] Implement GitHub GraphQL fetcher + cache (server-side function or cron snapshot).
+   - [ ] Build visualization component (heatmap or chart) with fallback mock data.
+   - [ ] Expose stat summary component with animation (count-up, gradient background).
+3. **[ ] C3.3 · Portfolio Experience Enhancements**
+   - [ ] Implement featured carousel + scroll anchors.
+   - [ ] Expand filter system (multi-select, tech tags, year filters).
+   - [ ] Add project detail modals/accordions with case-study content.
+4. **[ ] C3.4 · Performance & Accessibility**
+   - [ ] Lazy-load heavy assets (videos, Lottie animations).
+   - [ ] Audit keyboard navigation & focus states for interactive elements.
+   - [ ] Optimize bundle (code-splitting hero chart, memoization).
+
+## Epic D – Content Launch & Growth
+1. **[ ] D4.1 · Content Population & QA**
+   - [ ] Import curated project list (at least 12 apps with visuals & metrics).
+   - [ ] Verify links (live demos, GitHub repos) and update meta descriptions.
+   - [ ] Run cross-browser smoke tests (Chrome, Safari, Firefox, mobile Safari/Chrome).
+2. **[ ] D4.2 · Conversion & Engagement Hooks**
+   - [ ] Insert CTA blocks (newsletter, consulting inquiry) with A/B copy variations.
+   - [ ] Configure analytics events (hero CTA clicks, project filter interactions).
+   - [ ] Set up SEO enhancements (structured data, OpenGraph previews per project).
+3. **[ ] D4.3 · Launch Checklist & Post-Launch Iteration**
+   - [ ] Final content review with Ta (typo pass, tone alignment).
+   - [ ] Publish release notes + share on social channels.
+   - [ ] Collect metrics after 2 weeks and prioritize follow-up experiments.
+
+## Supporting Workstreams
+- **Spike S1:** Evaluate charting libraries (Recharts vs. D3 vs. GitHub-style heatmap) → deliver comparison doc.
+- **Spike S2:** Prototype GitHub API integration locally using personal access token + caching strategy.
+- **Spike S3:** Explore automated screenshot generation for project thumbnails.
+
+## Dependencies & Coordination
+- Align with branding assets (logos, gradients) stored in `/public/branding/` (to be confirmed).
+- Confirm availability of GitHub token with necessary scopes.
+- Coordinate with newsletter/contact team for CTA integration deadlines.
+
+## Definition of Done
+- Hero renders live GitHub stats with graceful fallback.
+- Minimum 12 projects populated with consistent schema and visuals.
+- Filters, featured carousel, and detail views fully responsive + accessible.
+- Performance scores meet targets; analytics & conversion events tracked.


### PR DESCRIPTION
## Summary
- add a comprehensive PRD outlining the weekend projects portfolio vision, goals, requirements, and release plan
- document execution-ready task plan covering strategy, design, engineering, and launch workstreams with subtasks and spikes

## Testing
- not run (documentation-only changes)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69100ab3fa888332b053b6b7aa8a422b)