### PR TITLE
Update/writing the unraveling of a promise

### DIFF
--- a/client/src/data/essays.ts
+++ b/client/src/data/essays.ts
@@ -11,12 +11,103 @@ export interface Essay {
 
 export const essays: Essay[] = [
   {
+    id: "the-unraveling-of-a-promise",
+    title: "The Unraveling of a Promise",
+    subtitle: "When the rules of the technology contract stop applying",
+    date: "December 23, 2025",
+    readingTime: "5 min read",
+    featured: true,
+    excerpt: "Two groups of people are sitting with the same feeling right now, though they have never met. One spent twenty-five years building a career in technology. The other just graduated. They share something: the slow realization that the rules they were promised no longer apply.",
+    content: `Two groups of people are sitting with the same feeling right now, though they have never met.
+
+One is in their mid-forties. They spent twenty-five years building a career in technology—learning languages, earning patents, leading teams across continents. They did everything right. They worked the long hours. They stayed current. They saved and invested. And two weeks ago, for the first time in their career, they were laid off.
+
+The other just graduated. They studied computer science because everyone said it was the safe choice. The practical choice. They learned to code, built projects, prepared for interviews. Now they are sending applications into silence. Entry-level positions that once numbered in thousands have shrunk to hundreds. Many have disappeared entirely.
+
+These two people would not recognize each other on the street. But they share something: the slow realization that the rules they were promised no longer apply.
+
+## The Veteran's Reckoning
+
+For decades, technology offered a clear contract. Learn the skills. Work hard. Stay current. In exchange: stability, good compensation, a place in the middle class or above.
+
+This contract held through recessions. It held through outsourcing waves. It held even as other industries hollowed out. Technology workers watched manufacturing jobs leave, watched retail collapse, watched journalism contract—and believed, with some justification, that their skills made them different.
+
+The 2008 financial crisis was a warning. Those who lived through it remember watching colleagues—mentors, people they respected—lose positions and break down. Smart people. Disciplined people. People who had done everything right.
+
+But even then, technology recovered faster than other sectors. The lesson many took was not that the contract was fragile, but that they needed to save more, invest better, prepare for the next storm while trusting the shelter would hold.
+
+The current wave of layoffs is different. It is not a response to crisis. The companies doing the cutting are profitable. They are simply choosing to need fewer people. Interest rates changed the math. Offshore resources became more accessible. AI tools began handling tasks that once required headcount.
+
+A person who spent a career building enterprise systems now sits in what feels like wilderness. The path they were on—clear, marked, leading somewhere—has ended. Multiple trails lead forward, but none are certain. Nothing is concrete.
+
+*This is what it feels like when a contract breaks.*
+
+## The Graduate's Void
+
+The person just entering the field faces something different but related: the contract was never offered to them at all.
+
+Previous generations of computer science graduates walked into a market hungry for anyone who could write code. Junior positions were plentiful. The work was often tedious—bug fixes, small features, maintenance tasks—but it served a purpose beyond the immediate output. It was training. It was how you became senior.
+
+That path is narrowing. AI tools now handle many tasks that once occupied entry-level engineers. Companies that previously hired five juniors to support one senior are recalculating. Some are deciding they need fewer people learning and more people who already know.
+
+The junior developer position was never just about cheap labor. It was the bottom of a ladder. Remove the bottom rungs and you don't just hurt the people trying to climb—you eventually run out of people at the top.
+
+But that is a long-term problem. Right now, the immediate reality is graduates competing for positions that may not exist in the numbers they were promised when they chose their major four years ago.
+
+*They are not being laid off. They are simply not being let in.*
+
+## What the Contract Actually Was
+
+When we examine what broke, we find that the contract was always more fragile than it appeared.
+
+The implicit promise of technology work was never written down. No company guaranteed lifetime employment. No industry body pledged to maintain a certain number of jobs. The contract existed in assumptions, in patterns that held long enough to seem like laws.
+
+**Work hard, stay current, and you will be fine.**
+
+This was true. Until it wasn't. The conditions that made it true—rapid industry growth, limited talent supply, geographic constraints on hiring—were circumstantial, not permanent.
+
+We are now learning what happens when circumstances change. The skills that guaranteed security for one generation may not guarantee it for the next. The ladder that existed may be rebuilt differently, or not at all.
+
+This is not a moral failing of companies or workers. It is what happens when an industry matures, when automation reaches a new category of work, when the economics shift. It has happened before in other fields. It is happening now in this one.
+
+## The Deeper Question
+
+Beyond the practical concerns—finding the next job, paying the bills, maintaining health insurance—there is a question that surfaces in these moments of disruption.
+
+**What was it all for?**
+
+The long hours. The missed time with family. The weekends spent learning new frameworks. The years building systems that were replaced, rebuilt, or abandoned. The colleague who worked late nights on a major initiative and then died of a heart issue before Christmas, and was functionally forgotten within a month.
+
+Technology workers were promised that their work mattered. That they were building the future. That the sacrifice of time and energy and presence was worth something.
+
+Some of it was. Some of what we built genuinely improved lives, created new possibilities, solved real problems.
+
+But some of it did not. Some of it was solving the same problem over and over. Some of it was building things that made no real difference to the world, that will not be remembered, that existed only to generate metrics that justified someone's budget.
+
+The layoff does not create this question. It simply removes the distractions that allowed us to avoid asking it.
+
+## No Resolution
+
+We want essays like this to end with answers. Five steps to navigate uncertainty. A framework for finding meaning. The optimistic turn that makes the difficult truth feel manageable.
+
+That is not honest to where we are.
+
+The veteran sitting in the wilderness does not know which path to take. The graduate facing a closed door does not know when it will open. The industry is in the middle of a transformation whose outcome is not yet clear.
+
+What we can say is this: the anxiety is real. It is not weakness. It is the appropriate response to genuine uncertainty.
+
+And it is shared. The person who spent decades in this industry and the person trying to enter it are facing the same fundamental question: *what happens when the rules change?*
+
+We do not have the answer yet.
+
+But we are asking it together, which is at least a beginning.`
+  },
+  {
     id: "ai-bubble-complicated",
     title: "Is There an AI Bubble? It's Complicated—and That's Actually the Interesting Part",
     subtitle: "Unpacking the nuances of AI investment across training, inference, and applications",
     date: "November 30, 2025",
     readingTime: "8 min read",
-    featured: true,
     excerpt: "The numbers certainly feel bubbly. OpenAI has committed to roughly $1.4 trillion in infrastructure over the next eight years. Nvidia became the first company to hit $5 trillion in market value this October. But asking 'is AI a bubble?' is a bit like asking 'is food overpriced?'",
     content: `Here's a question buzzing through every tech conference, investor meeting, and group chat right now: are we in an AI bubble?
 

--- a/client/src/pages/writing.tsx
+++ b/client/src/pages/writing.tsx
@@ -1,6 +1,6 @@
 import { Link } from "wouter";
 import { publications } from "@/data/publications";
-import { getFeaturedEssay } from "@/data/essays";
+import { getFeaturedEssay, essays } from "@/data/essays";
 import SEO from "@/components/seo";
 import SchemaMarkup from "@/components/schema-markup";
 import { ArrowRight, BookOpen, Linkedin, Newspaper } from "lucide-react";
@@ -95,6 +95,49 @@ export default function Writing() {
                 <div className="absolute bottom-0 left-0 right-0 h-1 bg-[#C45B3E] transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 origin-left" />
               </article>
             </Link>
+          </div>
+        </section>
+      )}
+
+      {/* More Essays Section */}
+      {essays.filter(essay => !essay.featured).length > 0 && (
+        <section className="pb-16 md:pb-20">
+          <div className="container max-w-4xl mx-auto px-4 sm:px-6">
+            <div className="text-center mb-8">
+              <h2 className="font-serif text-2xl md:text-3xl font-semibold text-[#1A1A1A] mb-4">
+                More Essays
+              </h2>
+              <p className="text-[#5C5C5C] max-w-xl mx-auto">
+                Previous writings on technology, AI, and the future of work.
+              </p>
+            </div>
+            <div className="space-y-6">
+              {essays.filter(essay => !essay.featured).map((essay) => (
+                <Link key={essay.id} href={`/essay/${essay.id}`}>
+                  <article className="group relative bg-white rounded-2xl overflow-hidden shadow-sm hover:shadow-xl transition-all duration-500 cursor-pointer border border-[#E8E4DF]">
+                    <div className="absolute inset-0 bg-gradient-to-br from-[#C45B3E]/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
+                    <div className="relative p-6 md:p-8">
+                      <div className="flex items-center gap-3 text-sm text-[#5C5C5C] mb-3">
+                        <span>{essay.date}</span>
+                        <span className="w-1 h-1 rounded-full bg-[#5C5C5C]" />
+                        <span>{essay.readingTime}</span>
+                      </div>
+                      <h3 className="font-serif text-xl md:text-2xl font-semibold text-[#1A1A1A] mb-3 group-hover:text-[#C45B3E] transition-colors duration-300 leading-tight">
+                        {essay.title}
+                      </h3>
+                      <p className="text-[#5C5C5C] leading-relaxed mb-4 line-clamp-2">
+                        {essay.excerpt}
+                      </p>
+                      <span className="inline-flex items-center gap-2 text-[#C45B3E] font-medium group-hover:gap-3 transition-all duration-300">
+                        Read essay
+                        <ArrowRight className="h-4 w-4" />
+                      </span>
+                    </div>
+                    <div className="absolute bottom-0 left-0 right-0 h-1 bg-[#C45B3E] transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 origin-left" />
+                  </article>
+                </Link>
+              ))}
+            </div>
           </div>
         </section>
       )}


### PR DESCRIPTION
This pull request adds a new essay and updates the essays listing on the writing page to better showcase non-featured essays. The most significant changes are the addition of a new essay entry and the introduction of a "More Essays" section to display all essays that are not marked as featured.

**Essays Data Updates:**

* Added a new essay entry, `"The Unraveling of a Promise"`, to the `essays` array in `essays.ts`, including its metadata and full content.
* Removed the `featured: true` flag from the `"Is There an AI Bubble? It's Complicated—and That's Actually the Interesting Part"` essay, so only one essay is now marked as featured.

**Writing Page Enhancements:**

* Updated the import in `writing.tsx` to bring in the full `essays` array, enabling access to all essays for display.
* Added a "More Essays" section to the writing page that lists all non-featured essays with their title, date, reading time, and excerpt, each linking to the full essay.